### PR TITLE
express-jwt@6.0.0 removed default algorithms

### DIFF
--- a/express/index.ts
+++ b/express/index.ts
@@ -31,6 +31,7 @@ const tryOrErr = async (res: Response, cb: () => void, statusCode: number) => {
 
 const jwtMiddleware = jwt({
     secret: JWT_SECRET,
+    algorithms: ['HS256'],
     userProperty: "cauth",
     getToken: function (req) {
         if (req.headers.authorization && req.headers.authorization.split(' ')[0] === 'Bearer') {


### PR DESCRIPTION
The latest version of express-jwt made the algorithms option required. This adds it.

https://stackoverflow.com/a/62797416